### PR TITLE
refactor(primitives): make value property private and use accessors

### DIFF
--- a/src/protocol/primitives/array.ts
+++ b/src/protocol/primitives/array.ts
@@ -16,7 +16,11 @@ export type ArrayDeserializer<T extends Serializable> = (buffer: ReadBuffer) => 
  * @see https://kafka.apache.org/protocol.html#protocol_types
  */
 export class Array<T extends Serializable> implements Serializable {
-  constructor(public readonly value: T[] | null) {}
+  constructor(private readonly _value: T[] | null) {}
+
+  public get value(): readonly T[] | null {
+    return this._value;
+  }
 
   public static deserialize<T extends Serializable>(buffer: ReadBuffer, deserializer: ArrayDeserializer<T>): Array<T> {
     const length = Int32.deserialize(buffer);

--- a/src/protocol/primitives/boolean.ts
+++ b/src/protocol/primitives/boolean.ts
@@ -7,7 +7,11 @@ import type { ReadBuffer, Serializable, WriteBuffer } from '../serialization';
  * @see https://kafka.apache.org/protocol.html#protocol_types
  */
 export class Boolean implements Serializable {
-  constructor(public readonly value: boolean) {}
+  constructor(private readonly _value: boolean) {}
+
+  public get value(): boolean {
+    return this._value;
+  }
 
   public static deserialize(buffer: ReadBuffer): Boolean {
     return new Boolean(buffer.readUInt8() !== 0);

--- a/src/protocol/primitives/bytes.ts
+++ b/src/protocol/primitives/bytes.ts
@@ -12,8 +12,12 @@ import { NullableBytes } from './nullable-bytes';
  * @see https://kafka.apache.org/protocol.html#protocol_types
  */
 export class Bytes extends NullableBytes implements Serializable {
-  constructor(public readonly value: Buffer) {
+  constructor(value: Buffer) {
     super(value);
+  }
+
+  public get value(): Buffer {
+    return super.value as Buffer;
   }
 
   public static deserialize(buffer: ReadBuffer): Bytes {

--- a/src/protocol/primitives/compact-array.ts
+++ b/src/protocol/primitives/compact-array.ts
@@ -10,7 +10,11 @@ import { UVarInt } from './uvarint';
  * @see https://kafka.apache.org/protocol.html#protocol_types
  */
 export class CompactArray<T extends Serializable> implements Serializable {
-  constructor(public readonly value: T[] | null) {}
+  constructor(private readonly _value: T[] | null) {}
+
+  public get value(): readonly T[] | null {
+    return this._value;
+  }
 
   public static deserialize<T extends Serializable>(
     buffer: ReadBuffer,

--- a/src/protocol/primitives/compact-bytes.ts
+++ b/src/protocol/primitives/compact-bytes.ts
@@ -9,8 +9,12 @@ import { CompactNullableBytes } from './compact-nullable-bytes';
  * @see https://kafka.apache.org/protocol.html#protocol_types
  */
 export class CompactBytes extends CompactNullableBytes implements Serializable {
-  constructor(public readonly value: Buffer) {
+  constructor(value: Buffer) {
     super(value);
+  }
+
+  public get value(): Buffer {
+    return super.value as Buffer;
   }
 
   public static deserialize(buffer: ReadBuffer): CompactBytes {

--- a/src/protocol/primitives/compact-nullable-bytes.ts
+++ b/src/protocol/primitives/compact-nullable-bytes.ts
@@ -9,7 +9,11 @@ import { UVarInt } from './uvarint';
  * @see https://kafka.apache.org/protocol.html#protocol_types
  */
 export class CompactNullableBytes implements Serializable {
-  constructor(public readonly value: Buffer | null) {}
+  constructor(private readonly _value: Buffer | null) {}
+
+  public get value(): Buffer | null {
+    return this._value;
+  }
 
   public static deserialize(buffer: ReadBuffer): CompactNullableBytes {
     const length = UVarInt.deserialize(buffer);

--- a/src/protocol/primitives/compact-nullable-string.ts
+++ b/src/protocol/primitives/compact-nullable-string.ts
@@ -9,7 +9,11 @@ import { CompactNullableBytes } from './compact-nullable-bytes';
  * @see https://kafka.apache.org/protocol.html#protocol_types
  */
 export class CompactNullableString implements Serializable {
-  constructor(public readonly value: string | null) {}
+  constructor(private readonly _value: string | null) {}
+
+  public get value(): string | null {
+    return this._value;
+  }
 
   public static deserialize(buffer: ReadBuffer): CompactNullableString {
     const compactNullableBytes = CompactNullableBytes.deserialize(buffer);

--- a/src/protocol/primitives/compact-string.ts
+++ b/src/protocol/primitives/compact-string.ts
@@ -10,8 +10,12 @@ import { CompactNullableString } from './compact-nullable-string';
  * @see https://kafka.apache.org/protocol.html#protocol_types
  */
 export class CompactString extends CompactNullableString implements Serializable {
-  constructor(public readonly value: string) {
+  constructor(value: string) {
     super(value);
+  }
+
+  public get value(): string {
+    return super.value as string;
   }
 
   public static deserialize(buffer: ReadBuffer): CompactString {

--- a/src/protocol/primitives/compressed-array.ts
+++ b/src/protocol/primitives/compressed-array.ts
@@ -5,9 +5,13 @@ import { Int32 } from './int32';
 
 export class CompressedArray<T extends Serializable> {
   constructor(
-    public readonly value: Array<T>,
+    private readonly _value: Array<T>,
     private readonly compressor: Compressor
   ) {}
+
+  public get value(): Array<T> {
+    return this._value;
+  }
 
   public static async deserialize<T extends Serializable>(
     buffer: ReadBuffer,

--- a/src/protocol/primitives/float64.ts
+++ b/src/protocol/primitives/float64.ts
@@ -7,7 +7,11 @@ import type { ReadBuffer, Serializable, WriteBuffer } from '../serialization';
  * @see https://kafka.apache.org/protocol.html#protocol_types
  */
 export class Float64 implements Serializable {
-  constructor(public readonly value: number) {}
+  constructor(private readonly _value: number) {}
+
+  public get value(): number {
+    return this._value;
+  }
 
   public static deserialize(buffer: ReadBuffer): Float64 {
     return new Float64(buffer.readDouble());

--- a/src/protocol/primitives/int16.ts
+++ b/src/protocol/primitives/int16.ts
@@ -11,8 +11,12 @@ export class Int16 implements Serializable {
   public static readonly MAX_VALUE = 32767;
   public static readonly MIN_VALUE = -32768;
 
-  constructor(public readonly value: number) {
-    checkValueIsInRange(value, Int16.MIN_VALUE, Int16.MAX_VALUE);
+  constructor(private readonly _value: number) {
+    checkValueIsInRange(_value, Int16.MIN_VALUE, Int16.MAX_VALUE);
+  }
+
+  public get value(): number {
+    return this._value;
   }
 
   public static deserialize(buffer: ReadBuffer): Int16 {

--- a/src/protocol/primitives/int32.ts
+++ b/src/protocol/primitives/int32.ts
@@ -11,8 +11,12 @@ export class Int32 implements Serializable {
   public static readonly MAX_VALUE = 2147483647;
   public static readonly MIN_VALUE = -2147483648;
 
-  constructor(public readonly value: number) {
-    checkValueIsInRange(value, Int32.MIN_VALUE, Int32.MAX_VALUE);
+  constructor(private readonly _value: number) {
+    checkValueIsInRange(_value, Int32.MIN_VALUE, Int32.MAX_VALUE);
+  }
+
+  public get value(): number {
+    return this._value;
   }
 
   public static deserialize(buffer: ReadBuffer): Int32 {

--- a/src/protocol/primitives/int64.ts
+++ b/src/protocol/primitives/int64.ts
@@ -11,8 +11,12 @@ export class Int64 implements Serializable {
   public static readonly MAX_VALUE = BigInt('9223372036854775807');
   public static readonly MIN_VALUE = BigInt('-9223372036854775808');
 
-  constructor(public readonly value: bigint) {
-    checkValueIsInRange(value, Int64.MIN_VALUE, Int64.MAX_VALUE);
+  constructor(private readonly _value: bigint) {
+    checkValueIsInRange(_value, Int64.MIN_VALUE, Int64.MAX_VALUE);
+  }
+
+  public get value(): bigint {
+    return this._value;
   }
 
   public static deserialize(buffer: ReadBuffer): Int64 {

--- a/src/protocol/primitives/int8.ts
+++ b/src/protocol/primitives/int8.ts
@@ -10,8 +10,12 @@ export class Int8 implements Serializable {
   public static readonly MAX_VALUE = 127;
   public static readonly MIN_VALUE = -128;
 
-  constructor(public readonly value: number) {
-    checkValueIsInRange(value, Int8.MIN_VALUE, Int8.MAX_VALUE);
+  constructor(private readonly _value: number) {
+    checkValueIsInRange(_value, Int8.MIN_VALUE, Int8.MAX_VALUE);
+  }
+
+  public get value(): number {
+    return this._value;
   }
 
   public static deserialize(buffer: ReadBuffer): Int8 {

--- a/src/protocol/primitives/nullable-bytes.ts
+++ b/src/protocol/primitives/nullable-bytes.ts
@@ -13,7 +13,11 @@ import { Int32 } from './int32';
  * @see https://kafka.apache.org/protocol.html#protocol_types
  */
 export class NullableBytes implements Serializable {
-  constructor(public readonly value: Buffer | null) {}
+  constructor(private readonly _value: Buffer | null) {}
+
+  public get value(): Buffer | null {
+    return this._value;
+  }
 
   public static deserialize(buffer: ReadBuffer): NullableBytes {
     const length = Int32.deserialize(buffer);

--- a/src/protocol/primitives/nullable-string.ts
+++ b/src/protocol/primitives/nullable-string.ts
@@ -13,7 +13,11 @@ import { Int16 } from './int16';
  * @see https://kafka.apache.org/protocol.html#protocol_types
  */
 export class NullableString implements Serializable {
-  constructor(public readonly value: string | null) {}
+  constructor(private readonly _value: string | null) {}
+
+  public get value(): string | null {
+    return this._value;
+  }
 
   public static deserialize(buffer: ReadBuffer): NullableString {
     const length = Int16.deserialize(buffer);

--- a/src/protocol/primitives/record-batch/record.spec.ts
+++ b/src/protocol/primitives/record-batch/record.spec.ts
@@ -1,7 +1,6 @@
 import { BufferUnderflowError } from '../../exceptions';
 import { ReadBuffer, WriteBuffer } from '../../serialization';
 import { CompactArray } from '../compact-array';
-import { CompactString } from '../compact-string';
 import { Int8 } from '../int8';
 import { VarInt } from '../varint';
 import { VarLong } from '../varlong';
@@ -101,7 +100,7 @@ describe('Record', () => {
   });
 
   it('should throw if there is no enough headers', () => {
-    const header = new RecordHeader(new CompactString('foo'), new VarIntBytes(Buffer.from('bar')));
+    const header = new RecordHeader(new RecordHeaderKey('foo'), new VarIntBytes(Buffer.from('bar')));
     const record = new Record({
       attributes,
       timestampDelta: new VarLong(0n),

--- a/src/protocol/primitives/record-batch/record.ts
+++ b/src/protocol/primitives/record-batch/record.ts
@@ -113,7 +113,11 @@ export class Record implements Serializable {
 }
 
 export class VarIntBytes implements Serializable {
-  constructor(public readonly value: Buffer | null) {}
+  constructor(private readonly _value: Buffer | null) {}
+
+  public get value(): Buffer | null {
+    return this._value;
+  }
 
   public static deserialize(buffer: ReadBuffer): VarIntBytes {
     const length = VarInt.deserialize(buffer);
@@ -137,7 +141,11 @@ export class VarIntBytes implements Serializable {
 }
 
 export class RecordHeaderKey implements Serializable {
-  constructor(public readonly value: string) {}
+  constructor(private readonly _value: string) {}
+
+  public get value(): string {
+    return this._value;
+  }
 
   public static deserialize(buffer: ReadBuffer): RecordHeaderKey {
     const varIntBytes = VarIntBytes.deserialize(buffer);

--- a/src/protocol/primitives/string.ts
+++ b/src/protocol/primitives/string.ts
@@ -11,8 +11,12 @@ import { NullableString } from './nullable-string';
  * @see https://kafka.apache.org/protocol.html#protocol_types
  */
 export class String extends NullableString implements Serializable {
-  constructor(public readonly value: string) {
+  constructor(value: string) {
     super(value);
+  }
+
+  public get value(): string {
+    return super.value as string;
   }
 
   public static deserialize(buffer: ReadBuffer): String {

--- a/src/protocol/primitives/uint32.ts
+++ b/src/protocol/primitives/uint32.ts
@@ -11,8 +11,12 @@ export class UInt32 implements Serializable {
   public static readonly MAX_VALUE = 4294967295;
   public static readonly MIN_VALUE = 0;
 
-  constructor(public readonly value: number) {
-    checkValueIsInRange(value, UInt32.MIN_VALUE, UInt32.MAX_VALUE);
+  constructor(private readonly _value: number) {
+    checkValueIsInRange(_value, UInt32.MIN_VALUE, UInt32.MAX_VALUE);
+  }
+
+  public get value(): number {
+    return this._value;
   }
 
   public static deserialize(buffer: ReadBuffer): UInt32 {

--- a/src/protocol/primitives/uuid.ts
+++ b/src/protocol/primitives/uuid.ts
@@ -10,10 +10,14 @@ import { IllegalArgumentError } from '../exceptions';
 export class Uuid implements Serializable {
   private static readonly NUMBER_OF_BYTES = 16;
 
-  constructor(public readonly value: Buffer) {
-    if (value.length !== Uuid.NUMBER_OF_BYTES) {
+  constructor(private readonly _value: Buffer) {
+    if (_value.length !== Uuid.NUMBER_OF_BYTES) {
       throw new IllegalArgumentError('UUID must have exactly 16 bytes.');
     }
+  }
+
+  public get value(): Buffer {
+    return this._value;
   }
 
   public static deserialize(buffer: ReadBuffer): Uuid {

--- a/src/protocol/primitives/uvarint.ts
+++ b/src/protocol/primitives/uvarint.ts
@@ -15,8 +15,12 @@ export class UVarInt implements Serializable {
   public static readonly MIN_VALUE = 0;
   private static readonly MAX_BYTES_TO_DECODE = 5;
 
-  constructor(public readonly value: number) {
-    checkValueIsInRange(value, UVarInt.MIN_VALUE, UVarInt.MAX_VALUE);
+  constructor(private readonly _value: number) {
+    checkValueIsInRange(_value, UVarInt.MIN_VALUE, UVarInt.MAX_VALUE);
+  }
+
+  public get value(): number {
+    return this._value;
   }
 
   public static deserialize(buffer: ReadBuffer): UVarInt {

--- a/src/protocol/primitives/varint.ts
+++ b/src/protocol/primitives/varint.ts
@@ -12,8 +12,12 @@ export class VarInt implements Serializable {
   public static readonly MAX_VALUE = 2_147_483_647;
   public static readonly MIN_VALUE = -2_147_483_648;
 
-  constructor(public readonly value: number) {
-    checkValueIsInRange(value, VarInt.MIN_VALUE, VarInt.MAX_VALUE);
+  constructor(private readonly _value: number) {
+    checkValueIsInRange(_value, VarInt.MIN_VALUE, VarInt.MAX_VALUE);
+  }
+
+  public get value(): number {
+    return this._value;
   }
 
   public static encodeZigZag(value: number): number {

--- a/src/protocol/primitives/varlong.ts
+++ b/src/protocol/primitives/varlong.ts
@@ -13,8 +13,12 @@ export class VarLong implements Serializable {
   public static readonly MAX_VALUE = BigInt('9223372036854775807');
   private static readonly MAX_BYTES_TO_DECODE = 10;
 
-  constructor(public readonly value: bigint) {
-    checkValueIsInRange(value, VarLong.MIN_VALUE, VarLong.MAX_VALUE);
+  constructor(private readonly _value: bigint) {
+    checkValueIsInRange(_value, VarLong.MIN_VALUE, VarLong.MAX_VALUE);
+  }
+
+  public get value(): bigint {
+    return this._value;
   }
 
   public static encodeZigZag(value: bigint): bigint {


### PR DESCRIPTION
closes Refactor primitive types, so they cannot be confused #56